### PR TITLE
Add funding arbitrage configuration

### DIFF
--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,4 +1,5 @@
 *.yml
 !global_conf.yml
+!funding_rate_arb.yml
 *.json
 .password_verification

--- a/conf/funding_rate_arb.yml
+++ b/conf/funding_rate_arb.yml
@@ -1,0 +1,9 @@
+min_funding_rate_profitability: 0.0005
+position_size_quote: 100
+leverage: 5
+connectors:
+  - bybit_perpetual
+  - kucoin_perpetual
+tokens:
+  - BTC
+  - ETH

--- a/conf/global_conf.yml
+++ b/conf/global_conf.yml
@@ -1,2 +1,3 @@
 script_modules:
   - core_ext.state_sync
+config_path: funding_rate_arb.yml


### PR DESCRIPTION
## Summary
- add default funding arbitrage config
- reference config file in `global_conf.yml`
- allow file in `.gitignore`

## Testing
- `pip install coverage`
- `make test` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d349e0730832fa0c3b2bc7c928e50