### PR TITLE
Add env_file to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     tty: true
     stdin_open: true
     network_mode: host
+    env_file: .env
     environment:
       HEALTH_PORT: 5723
     healthcheck:


### PR DESCRIPTION
## Summary
- update docker-compose.yml with env_file for hb service
- create .env with placeholder exchange API keys and password

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d3bfb93c4832f8e8b34165a4a7672