### PR TITLE
Align health check port

### DIFF
--- a/docker/Dockerfile.extend
+++ b/docker/Dockerfile.extend
@@ -10,4 +10,4 @@ COPY docker/health_server.py ./health_server.py
 
 CMD bash -c "python /home/hummingbot/health_server.py & /scripts/start.sh"
 
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8080/livez || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:5723/livez || exit 1

--- a/docker/health_server.py
+++ b/docker/health_server.py
@@ -19,5 +19,5 @@ def metrics():
     return jsonify(data)
 
 if __name__ == '__main__':
-    port = int(os.getenv('HEALTH_PORT', '8080'))
+    port = int(os.getenv('HEALTH_PORT', '5723'))
     app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- ensure health server defaults to port 5723
- update Dockerfile healthcheck to use port 5723

## Testing
- `make test` *(fails: coverage not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3bfc0550832f909cb92a0453984d