### PR TITLE
Fix multiple identified bugs

### DIFF
--- a/hummingbot/connector/exchange_base.py
+++ b/hummingbot/connector/exchange_base.py
@@ -165,10 +165,11 @@ class ExchangeBase(ConnectorBase):
     def c_get_vwap_for_volume(self, trading_pair: str, is_buy: bool, volume):
         order_book = self.c_get_order_book(trading_pair)
         result = order_book.c_get_vwap_for_volume(is_buy, float(volume))
+        query_price = Decimal(str(result.query_price))
         query_volume = Decimal(str(result.query_volume))
         result_price = Decimal(str(result.result_price))
         result_volume = Decimal(str(result.result_volume))
-        return ClientOrderBookQueryResult(s_decimal_NaN,
+        return ClientOrderBookQueryResult(query_price,
                                           query_volume,
                                           result_price,
                                           result_volume)
@@ -176,10 +177,11 @@ class ExchangeBase(ConnectorBase):
     def c_get_price_for_quote_volume(self, trading_pair: str, is_buy: bool, volume: float):
         order_book = self.c_get_order_book(trading_pair)
         result = order_book.c_get_price_for_quote_volume(is_buy, float(volume))
+        query_price = Decimal(str(result.query_price))
         query_volume = Decimal(str(result.query_volume))
         result_price = Decimal(str(result.result_price))
         result_volume = Decimal(str(result.result_volume))
-        return ClientOrderBookQueryResult(s_decimal_NaN,
+        return ClientOrderBookQueryResult(query_price,
                                           query_volume,
                                           result_price,
                                           result_volume)
@@ -187,10 +189,11 @@ class ExchangeBase(ConnectorBase):
     def c_get_price_for_volume(self, trading_pair: str, is_buy: bool, volume):
         order_book = self.c_get_order_book(trading_pair)
         result = order_book.c_get_price_for_volume(is_buy, float(volume))
+        query_price = Decimal(str(result.query_price))
         query_volume = Decimal(str(result.query_volume))
         result_price = Decimal(str(result.result_price))
         result_volume = Decimal(str(result.result_volume))
-        return ClientOrderBookQueryResult(s_decimal_NaN,
+        return ClientOrderBookQueryResult(query_price,
                                           query_volume,
                                           result_price,
                                           result_volume)

--- a/hummingbot/connector/exchange_base.pyx
+++ b/hummingbot/connector/exchange_base.pyx
@@ -168,10 +168,11 @@ cdef class ExchangeBase(ConnectorBase):
         cdef:
             OrderBook order_book = self.c_get_order_book(trading_pair)
             OrderBookQueryResult result = order_book.c_get_vwap_for_volume(is_buy, float(volume))
+            object query_price = Decimal(str(result.query_price))
             object query_volume = Decimal(str(result.query_volume))
             object result_price = Decimal(str(result.result_price))
             object result_volume = Decimal(str(result.result_volume))
-        return ClientOrderBookQueryResult(s_decimal_NaN,
+        return ClientOrderBookQueryResult(query_price,
                                           query_volume,
                                           result_price,
                                           result_volume)
@@ -180,10 +181,11 @@ cdef class ExchangeBase(ConnectorBase):
         cdef:
             OrderBook order_book = self.c_get_order_book(trading_pair)
             OrderBookQueryResult result = order_book.c_get_price_for_quote_volume(is_buy, float(volume))
+            object query_price = Decimal(str(result.query_price))
             object query_volume = Decimal(str(result.query_volume))
             object result_price = Decimal(str(result.result_price))
             object result_volume = Decimal(str(result.result_volume))
-        return ClientOrderBookQueryResult(s_decimal_NaN,
+        return ClientOrderBookQueryResult(query_price,
                                           query_volume,
                                           result_price,
                                           result_volume)
@@ -192,10 +194,11 @@ cdef class ExchangeBase(ConnectorBase):
         cdef:
             OrderBook order_book = self.c_get_order_book(trading_pair)
             OrderBookQueryResult result = order_book.c_get_price_for_volume(is_buy, float(volume))
+            object query_price = Decimal(str(result.query_price))
             object query_volume = Decimal(str(result.query_volume))
             object result_price = Decimal(str(result.result_price))
             object result_volume = Decimal(str(result.result_volume))
-        return ClientOrderBookQueryResult(s_decimal_NaN,
+        return ClientOrderBookQueryResult(query_price,
                                           query_volume,
                                           result_price,
                                           result_volume)

--- a/hummingbot/connector/in_flight_order_base.py
+++ b/hummingbot/connector/in_flight_order_base.py
@@ -176,10 +176,10 @@ class InFlightOrderBase:
     async def wait_until_completely_filled(self):
         await self.completely_filled_event.wait()
 
-    def _creation_timestamp_from_order_id(self) -> int:
-        timestamp = -1
+    def _creation_timestamp_from_order_id(self) -> float:
+        timestamp = -1.0
         if len(self.client_order_id) > 16:
             nonce_component = self.client_order_id[-16:]
             timestamp_string = f"{nonce_component[:10]}.{nonce_component[-6:]}"
-            timestamp = float(timestamp_string) if nonce_component.isnumeric() else -1
+            timestamp = float(timestamp_string) if nonce_component.isnumeric() else -1.0
         return timestamp

--- a/hummingbot/connector/in_flight_order_base.pyx
+++ b/hummingbot/connector/in_flight_order_base.pyx
@@ -175,10 +175,10 @@ cdef class InFlightOrderBase:
     async def wait_until_completely_filled(self):
         await self.completely_filled_event.wait()
 
-    def _creation_timestamp_from_order_id(self) -> int:
-        timestamp = -1
+    def _creation_timestamp_from_order_id(self) -> float:
+        timestamp = -1.0
         if len(self.client_order_id) > 16:
             nonce_component = self.client_order_id[-16:]
             timestamp_string = f"{nonce_component[:10]}.{nonce_component[-6:]}"
-            timestamp = float(timestamp_string) if nonce_component.isnumeric() else -1
+            timestamp = float(timestamp_string) if nonce_component.isnumeric() else -1.0
         return timestamp

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ if is_posix:
         os.environ["CFLAGS"] = "-std=c++11"
 
 if os.environ.get("WITHOUT_CYTHON_OPTIMIZATIONS"):
-    os.environ["CFLAGS"] += " -O0"
+    if "CFLAGS" in os.environ:
+        os.environ["CFLAGS"] += " -O0"
+    else:
+        os.environ["CFLAGS"] = "-O0"
 
 
 # Avoid a gcc warning below:

--- a/setup_no_cython.py
+++ b/setup_no_cython.py
@@ -16,7 +16,10 @@ if is_posix:
         os.environ["CFLAGS"] = "-std=c++11"
 
 if os.environ.get("WITHOUT_CYTHON_OPTIMIZATIONS"):
-    os.environ["CFLAGS"] += " -O0"
+    if "CFLAGS" in os.environ:
+        os.environ["CFLAGS"] += " -O0"
+    else:
+        os.environ["CFLAGS"] = "-O0"
 
 
 def main():


### PR DESCRIPTION
```
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR addresses three identified bugs:

1.  **Order Book Query Methods Return Incorrect Data**: The `c_get_vwap_for_volume`, `c_get_price_for_quote_volume`, and `c_get_price_for_volume` methods in `ExchangeBase` (both Python and Cython) now correctly use the `query_price` from the underlying `OrderBookQueryResult` instead of hardcoding `s_decimal_NaN`. This ensures consistency, as the underlying methods correctly return `NaN` for non-price-based queries.
2.  **Type Mismatch in Creation Timestamp Method**: The `_creation_timestamp_from_order_id` method in `InFlightOrderBase` (both Python and Cython) has its return type annotation corrected from `int` to `float`, matching its actual return value.
3.  **Environment Variable Handling Fails on Windows**: The `setup.py` and `setup_no_cython.py` scripts now safely handle the `WITHOUT_CYTHON_OPTIMIZATIONS` environment variable by checking if `os.environ["CFLAGS"]` exists before attempting to append to it, preventing `KeyError` on non-POSIX systems.

**Tests performed by the developer**:

*   Verified `query_price` propagation in `ExchangeBase` order book query methods.
*   Confirmed type consistency for `_creation_timestamp_from_order_id`.
*   Validated environment variable handling logic in setup scripts.

**Tips for QA testing**:

*   Verify that `c_get_vwap_for_volume`, `c_get_price_for_quote_volume`, and `c_get_price_for_volume` methods in `ExchangeBase` return `ClientOrderBookQueryResult` with `query_price` as `NaN` (as expected for volume-based queries).
*   Check that `_creation_timestamp_from_order_id` returns a `float`.
*   If possible, test the setup process on a Windows environment with the `WITHOUT_CYTHON_OPTIMIZATIONS` environment variable set to ensure no `KeyError` occurs.
```

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-9b0952cf-b5d5-4bc6-894b-2d5ebb01df19) · [Cursor](https://cursor.com/background-agent?bcId=bc-9b0952cf-b5d5-4bc6-894b-2d5ebb01df19)